### PR TITLE
[LaraPackagePort] Analyse for Laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,13 +23,13 @@
     ],
     "require": {
         "php": "^7.0",
-        "illuminate/support": "~5.2.0|~5.3.0|~5.4.0|~5.5.x-dev",
+        "illuminate/support": "~5.2.0|~5.3.0|~5.4.0|~5.5.x-dev|~5.5.x-dev",
         "nesbot/carbon": "^1.0",
         "nikic/php-parser": "^2.0|^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.2",
-        "orchestra/testbench": "^3.2|~3.5.x-dev",
+        "orchestra/testbench": "^3.2|~3.5.x-dev|~3.5.x-dev",
         "mockery/mockery": "^0.9.5"
     },
     "autoload": {
@@ -53,3 +53,4 @@
         }
     }
 }
+

--- a/composer.json
+++ b/composer.json
@@ -22,14 +22,14 @@
         }
     ],
     "require": {
-        "php" : "^7.0",
-        "illuminate/support": "~5.2.0|~5.3.0|~5.4.0",
+        "php": "^7.0",
+        "illuminate/support": "~5.2.0|~5.3.0|~5.4.0|~5.5.x-dev",
         "nesbot/carbon": "^1.0",
-        "nikic/php-parser":"^2.0|^3.0"
+        "nikic/php-parser": "^2.0|^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.0",
-        "orchestra/testbench":"^3.2",
+        "phpunit/phpunit": "^6.2",
+        "orchestra/testbench": "^3.2|~3.5.x-dev",
         "mockery/mockery": "^0.9.5"
     },
     "autoload": {


### PR DESCRIPTION
This Pull-Requests help you to prepare your Package for Laravel 5.5. I've tested it automated and this was the PHPUnit Result:
PHPUnit 6.3-dev by Sebastian Bergmann and contributors.

Runtime:       PHP 7.1.7 with Xdebug 2.5.5
Configuration: /Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-model-cleanup/phpunit.xml.dist

....                                                                4 / 4 (100%)

Time: 14.97 seconds, Memory: 18.00MB

OK (4 tests, 8 assertions)

Generating code coverage report in Clover XML format ... done

Generating code coverage report in HTML format ... done

Nice looks really good! There are no Errors so it might work in Laravel 5.5 without any adjustments