### PR TITLE
Fix #14: Files with no class cause type error

### DIFF
--- a/src/CleanUpModelsCommand.php
+++ b/src/CleanUpModelsCommand.php
@@ -86,6 +86,10 @@ class CleanUpModelsCommand extends Command
 
             return $this->getFullyQualifiedClassNameFromFile($path);
 
+        })->filter(function (string $className) {
+
+            return !empty($className);
+
         });
     }
 
@@ -110,6 +114,6 @@ class CleanUpModelsCommand extends Command
             ->map(function (Class_ $statement) {
                 return $statement->namespacedName->toString();
             })
-            ->first();
+            ->first() ?? '';
     }
 }

--- a/tests/DatabaseCleanupTest.php
+++ b/tests/DatabaseCleanupTest.php
@@ -26,8 +26,8 @@ class DatabaseCleanupTest extends TestCase
 
         $this->app['config']->set('model-cleanup',
             [
-                'models' => [CleanableItem::class],
                 'directories' => [],
+                'models' => [CleanableItem::class],
             ]);
 
         $this->app->make(Kernel::class)->call('clean:models');
@@ -63,8 +63,8 @@ class DatabaseCleanupTest extends TestCase
     {
         $this->app['config']->set('model-cleanup',
             [
-                'models' => [],
                 'directories' => [__DIR__.'/Models'],
+                'models' => [],
             ]);
     }
 }

--- a/tests/FindModelsFromConfigTest.php
+++ b/tests/FindModelsFromConfigTest.php
@@ -2,11 +2,8 @@
 
 namespace Spatie\ModelCleanup\Test;
 
-use Spatie\ModelCleanup\ModelWasCleanedUp;
 use Spatie\ModelCleanup\CleanUpModelsCommand;
 use Spatie\ModelCleanup\Test\Models\CleanableItem;
-use Spatie\ModelCleanup\Test\Models\UncleanableItem;
-use Illuminate\Contracts\Console\Kernel;
 
 class FindModelsFromConfigTest extends TestCase
 {

--- a/tests/FindModelsFromConfigTest.php
+++ b/tests/FindModelsFromConfigTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Spatie\ModelCleanup\Test;
+
+use Spatie\ModelCleanup\ModelWasCleanedUp;
+use Spatie\ModelCleanup\CleanUpModelsCommand;
+use Spatie\ModelCleanup\Test\Models\CleanableItem;
+use Spatie\ModelCleanup\Test\Models\UncleanableItem;
+use Illuminate\Contracts\Console\Kernel;
+
+class FindModelsFromConfigTest extends TestCase
+{
+    /** @test */
+    public function it_can_find_class_name_from_file()
+    {
+        $method = self::getMethod(CleanUpModelsCommand::class, 'getFullyQualifiedClassNameFromFile');
+        $cmd = new CleanUpModelsCommand(app()->make('files'));
+
+        $className = $method->invokeArgs($cmd, ["./tests/Models/CleanableItem.php"]);
+
+        $this->assertTrue($className !== "");
+        
+        $className = $method->invokeArgs($cmd, ["./tests/Models/NotAClass.php"]);
+
+        $this->assertTrue($className === "");
+    }
+
+    /** @test */
+    public function it_can_find_class_names_from_directory()
+    {
+        $method = self::getMethod(CleanUpModelsCommand::class, 'getClassNamesInDirectory');
+        $cmd = new CleanUpModelsCommand(app()->make('files'));
+
+        $classNames = $method->invokeArgs($cmd, ["./tests/Models"]);
+
+        $this->assertContains(CleanableItem::class, $classNames);
+
+        $this->assertNotContains(null, $classNames);
+    }
+
+    protected static function getMethod($class, $name)
+    {
+        $class = new \ReflectionClass($class);
+        $method = $class->getMethod($name);
+        $method->setAccessible(true);
+        return $method;
+    }
+}

--- a/tests/Models/NotAClass.php
+++ b/tests/Models/NotAClass.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Spatie\ModelCleanup\Test\Models;
+
+trait NotAClass
+{
+
+}


### PR DESCRIPTION
Should be self explanatory, but:

- To keep 7.0 compat, I used `?? ''` to prevent returning `null` when not finding a class in a file, instead of making the function nullable (which is 7.1+ only)
- I filter out empty strings as invalid class names afterwards
- I added a non-class model file to the tests (the existing tests fail with that file added without my above changes)
- I added a couple of unit tests for the functions I modified using reflection to invoke the protected functions
- Kinda out of scope, but an additional thing I tossed in - the config arrays in the existing test weren't ordered the same as the actual config array, so I reordered them to reduce the cognitive load when reading it

I'm still learning how to write tests in PHP, gave myself the challenge to do this for practice 😄 