### PR TITLE
Option to forceDelete models that use the soft deletes

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ return [
 ```
 
 ## Usage
+
+### Configure models to remove
+
 All models that you want to clean up must implement the `GetsCleanedUp`-interface. In the required
 `cleanUp`-method you can specify a query that selects the records that should be deleted.
 
@@ -79,15 +82,47 @@ class LogItem extends Model implements GetsCleanedUp
 {
     ...
     
-     public static function cleanUp(Builder $query) : Builder
-     {
+    public static function cleanUp(Builder $query) : Builder
+    {
         return $query->where('created_at', '<', Carbon::now()->subYear());
-     }
+    }
     
 }
 ```
 
 When running the console command `clean:models` all newsItems older than a year will be deleted.
+
+### Configure models to forceRemove
+
+All models that use SoftDeletes function that you want to clean up completly from the database must implement the `GetsForcedCleanedUp`-interface. In the required
+`cleanUp`-method you can specify a query that selects the records that should be forceDeleted.
+
+Let's say you have a model called `LogItem`, that you would like to  cleaned up. In this case your model could look like this:
+
+``` php
+use Spatie\ModelCleanup\GetsCleanedUp;
+use Illuminate\Database\Eloquent\Builder;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class LogItem extends Model implements GetsForcedCleanedUp
+{
+    use SoftDeletes;
+    ...
+    
+    public static function cleanUp(Builder $query) : Builder
+    {
+        return $query->onlyTrashed()->where('deleted_at', '<', Carbon::now()->subDay());
+    }
+    
+}
+```
+
+When running the console command `clean:models` all newsItems deleted before than a year will be deleted completly from the database.
+
+### Command 
+
+When running the console command `clean:models` all the items on cleanUp will be deleted.
 
 This command can be scheduled in Laravel's console kernel.
 

--- a/src/CleanUpModelsCommand.php
+++ b/src/CleanUpModelsCommand.php
@@ -38,9 +38,13 @@ class CleanUpModelsCommand extends Command
     {
         $this->comment('Cleaning models...');
 
+        // Cleaning Normal models
         $cleanableModels = $this->getModelsThatShouldBeCleanedUp();
-
         $this->cleanUp($cleanableModels);
+
+        // Cleaning softdeletes models
+        $cleanableModels = $this->getModelsThatShouldBeForcedCleanedUp();
+        $this->forceCleanUp($cleanableModels);
 
         $this->comment('All done!');
     }
@@ -58,11 +62,37 @@ class CleanUpModelsCommand extends Command
             });
     }
 
+    protected function getModelsThatShouldBeForcedCleanedUp() : Collection
+    {
+        $directories = config('model-cleanup.directories');
+
+        $modelsFromDirectories = $this->getAllModelsFromEachDirectory($directories);
+
+        return $modelsFromDirectories
+            ->merge(collect(config('model-cleanup.models')))
+            ->filter(function ($modelClass) {
+                return in_array(GetsForcedCleanedUp::class, class_implements($modelClass));
+            });
+    }
+
     protected function cleanUp(Collection $cleanableModels)
     {
         $cleanableModels->each(function (string $modelClass) {
 
             $numberOfDeletedRecords = $modelClass::cleanUp($modelClass::query())->delete();
+
+            event(new ModelWasCleanedUp($modelClass, $numberOfDeletedRecords));
+
+            $this->info("Deleted {$numberOfDeletedRecords} record(s) from {$modelClass}.");
+
+        });
+    }
+
+    protected function forceCleanUp(Collection $cleanableModels)
+    {
+        $cleanableModels->each(function (string $modelClass) {
+
+            $numberOfDeletedRecords = $modelClass::cleanUp($modelClass::query())->forceDelete();
 
             event(new ModelWasCleanedUp($modelClass, $numberOfDeletedRecords));
 

--- a/src/CleanUpModelsCommand.php
+++ b/src/CleanUpModelsCommand.php
@@ -92,7 +92,7 @@ class CleanUpModelsCommand extends Command
     {
         $cleanableModels->each(function (string $modelClass) {
 
-            $numberOfDeletedRecords = $modelClass::cleanUp($modelClass::query())->forceDelete();
+            $numberOfDeletedRecords = $modelClass::forceCleanUp($modelClass::query())->forceDelete();
 
             event(new ModelWasCleanedUp($modelClass, $numberOfDeletedRecords));
 

--- a/src/GetsForcedCleanedUp.php
+++ b/src/GetsForcedCleanedUp.php
@@ -14,5 +14,5 @@ interface GetsForcedCleanedUp
      *
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public static function cleanUp(Builder $query) : Builder;
+    public static function forceCleanUp(Builder $query) : Builder;
 }

--- a/src/GetsForcedCleanedUp.php
+++ b/src/GetsForcedCleanedUp.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spatie\ModelCleanup;
+
+use Illuminate\Database\Eloquent\Builder;
+
+interface GetsForcedCleanedUp
+{
+    /**
+     * Returns a query that determines which models will get completly cleaned up. On
+     * cleanup, the `forceDelete` method will be appended to the query.
+     *
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public static function cleanUp(Builder $query) : Builder;
+}

--- a/tests/DatabaseForceCleanupTest.php
+++ b/tests/DatabaseForceCleanupTest.php
@@ -13,7 +13,7 @@ class DatabaseForceCleanupTest extends TestCase
     {
         $this->assertEquals(20, ForceCleanableItem::withTrashed()->count());
 
-        ForceCleanableItem::cleanUp(ForceCleanableItem::query())->forceDelete();
+        ForceCleanableItem::forceCleanUp(ForceCleanableItem::query())->forceDelete();
 
         $this->assertEquals(10, ForceCleanableItem::withTrashed()->count());
     }

--- a/tests/DatabaseForceCleanupTest.php
+++ b/tests/DatabaseForceCleanupTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Spatie\ModelCleanup\Test;
+
+use Spatie\ModelCleanup\ModelWasCleanedUp;
+use Spatie\ModelCleanup\Test\Models\ForceCleanableItem;
+use Illuminate\Contracts\Console\Kernel;
+
+class DatabaseForceCleanupTest extends TestCase
+{
+    /** @test */
+    public function it_can_delete_expired_records_from_a_database()
+    {
+        $this->assertEquals(20, ForceCleanableItem::withTrashed()->count());
+
+        ForceCleanableItem::cleanUp(ForceCleanableItem::query())->forceDelete();
+
+        $this->assertEquals(10, ForceCleanableItem::withTrashed()->count());
+    }
+
+    /** @test */
+    public function it_can_cleanup_the_models_specified_in_the_config_file()
+    {
+        $this->assertEquals(20, ForceCleanableItem::withTrashed()->count());
+
+        $this->app['config']->set('model-cleanup',
+            [
+                'directories' => [],
+                'models' => [ForceCleanableItem::class],
+            ]);
+
+        $this->app->make(Kernel::class)->call('clean:models');
+
+        $this->assertEquals(10, ForceCleanableItem::withTrashed()->count());
+    }
+
+    /** @test */
+    public function it_can_cleanup_the_directories_specified_in_the_config_file()
+    {
+        $this->assertEquals(20, ForceCleanableItem::withTrashed()->count());
+
+        $this->setConfigThatCleansUpDirectory();
+
+        $this->app->make(Kernel::class)->call('clean:models');
+
+        $this->assertEquals(10, ForceCleanableItem::withTrashed()->count());
+    }
+
+    protected function setConfigThatCleansUpDirectory()
+    {
+        $this->app['config']->set('model-cleanup',
+            [
+                'directories' => [__DIR__.'/Models'],
+                'models' => [],
+            ]);
+    }
+}

--- a/tests/Models/ForceCleanableItem.php
+++ b/tests/Models/ForceCleanableItem.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Spatie\ModelCleanup\Test\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Spatie\ModelCleanup\GetsForcedCleanedUp;
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class ForceCleanableItem extends Model implements GetsForcedCleanedUp
+{
+	use SoftDeletes;
+
+    protected $table = 'forced_cleanable_items';
+    protected $guarded = [];
+
+    public static function cleanUp(Builder $query) : Builder
+    {
+        return $query->onlyTrashed()->where('deleted_at', '<', Carbon::now()->subDay());
+    }
+}

--- a/tests/Models/ForceCleanableItem.php
+++ b/tests/Models/ForceCleanableItem.php
@@ -15,7 +15,7 @@ class ForceCleanableItem extends Model implements GetsForcedCleanedUp
     protected $table = 'forced_cleanable_items';
     protected $guarded = [];
 
-    public static function cleanUp(Builder $query) : Builder
+    public static function forceCleanUp(Builder $query) : Builder
     {
         return $query->onlyTrashed()->where('deleted_at', '<', Carbon::now()->subDay());
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use Illuminate\Database\Schema\Blueprint;
 use Spatie\ModelCleanup\ModelCleanupServiceProvider;
 use Spatie\ModelCleanup\Test\Models\CleanableItem;
+use Spatie\ModelCleanup\Test\Models\ForceCleanableItem;
 use Spatie\ModelCleanup\Test\Models\UncleanableItem;
 use Event;
 
@@ -50,6 +51,13 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
             $table->timestamp('created_at');
         });
 
+        $app['db']->connection()->getSchemaBuilder()->create('forced_cleanable_items', function (Blueprint $table) {
+            $table->increments('id');
+            $table->timestamp('created_at');
+            $table->timestamp('updated_at');
+            $table->timestamp('deleted_at');
+        });
+
         $app['db']->connection()->getSchemaBuilder()->create('uncleanable_items', function (Blueprint $table) {
             $table->increments('id');
             $table->timestamp('created_at');
@@ -72,6 +80,16 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
 
             CleanableItem::create([
                 'created_at' => Carbon::now()->subMonth(),
+            ]);
+
+            ForceCleanableItem::create([
+                'created_at' => Carbon::now()->subMonth(),
+                'deleted_at' => Carbon::now()->subDays(2)
+            ]);
+
+            ForceCleanableItem::create([
+                'created_at' => Carbon::now()->subMonth(),
+                'deleted_at' => Carbon::now()
             ]);
 
             UncleanableItem::create([


### PR DESCRIPTION
Hi everyone, this feature will help to anyone to add the cleanUp function to soft deletes models. 

Right now if you use the function on softdeletes models they dont completly remove them, because the actual interface just delete them, but there isnt any option to forceDelete.

With this changes any user will be able to for example, remove items deleted with 1 day ago or more.

```
use Illuminate\Database\Eloquent\Builder;
use Illuminate\Database\Eloquent\Model;
use Spatie\ModelCleanup\GetsForcedCleanedUp;
use Carbon\Carbon;
use Illuminate\Database\Eloquent\SoftDeletes;

class ForceCleanableItem extends Model implements GetsForcedCleanedUp
{
    use SoftDeletes;

    protected $guarded = [];

    public static function forceCleanUp(Builder $query) : Builder
    {
        return $query->onlyTrashed()->where('deleted_at', '<', Carbon::now()->subDay());
    }
}

```