### PR TITLE
Update badge alt text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Clean up unneeded records
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/spatie/laravel-model-cleanup.svg?style=flat-square)](https://packagist.org/packages/spatie/laravel-model-cleanup)
-[![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
+[![MIT Licensed](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
 [![Build Status](https://img.shields.io/travis/spatie/laravel-model-cleanup/master.svg?style=flat-square)](https://travis-ci.org/spatie/laravel-model-cleanup)
 [![Quality Score](https://img.shields.io/scrutinizer/g/spatie/laravel-model-cleanup.svg?style=flat-square)](https://scrutinizer-ci.com/g/spatie/laravel-model-cleanup)
 [![Total Downloads](https://img.shields.io/packagist/dt/spatie/laravel-model-cleanup.svg?style=flat-square)](https://packagist.org/packages/spatie/laravel-model-cleanup)


### PR DESCRIPTION
If the bade doesn't load, this will still allow users to see what the license is. It is also beneficial for users who use screen readers.