### PR TITLE
use CarbonPeriod

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -48,7 +48,8 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
 
     protected function assertModelsExistForDays(array $expectedDates)
     {
-        $actualDates = TestModel::all()
+        $actualDates = TestModel::query()
+            ->latest()
             ->pluck('created_at')
             ->map(fn (Carbon $createdAt) => $createdAt->format('Y-m-d'))
             ->toArray();

--- a/tests/TestModelFactory.php
+++ b/tests/TestModelFactory.php
@@ -3,6 +3,7 @@
 namespace Spatie\ModelCleanup\Test;
 
 use Carbon\Carbon;
+use Carbon\CarbonPeriod;
 use Spatie\ModelCleanup\Test\Models\TestModel;
 
 class TestModelFactory
@@ -32,10 +33,7 @@ class TestModelFactory
 
     public function create()
     {
-        $createdAt = $this->startingFrom;
-
-        foreach (range(1, $this->numberOfDays) as $i) {
-            TestModel::create(['created_at' => $createdAt->subDay()]);
-        }
+        CarbonPeriod::create($this->startingFrom->subDays($this->numberOfDays), $this->numberOfDays)
+            ->forEach(fn(Carbon $created_at) => TestModel::create(compact('created_at')));
     }
 }


### PR DESCRIPTION
Hey @freekmurze,

watched your stream this morning and thought if CarbonPeriod would fit better here.

Added `latest()` to fix order
```php
$actualDates = TestModel::query()
            ->latest()
```

Feel free to drop or merge it.
Cheers Adrian